### PR TITLE
cbmc: test compile Xen

### DIFF
--- a/.github/workflows/build-and-test-Xen.yml
+++ b/.github/workflows/build-and-test-Xen.yml
@@ -1,6 +1,8 @@
 name: Build and Test Xen
 
-on: [push]
+on:
+  pull_request:
+    branches: [ develop ]
 
 jobs:
   Linux:

--- a/.github/workflows/build-and-test-Xen.yml
+++ b/.github/workflows/build-and-test-Xen.yml
@@ -22,5 +22,17 @@ jobs:
       run: make -C src minisat2-download
       run: make -C src cbmc.dir goto-cc.dir goto-diff.dir
 
+    - name: get one-line-scan
+      run: git clone https://github.com/awslabs/one-line-scan.git
+
     - name: get Xen 4.13
       run: git clone git://xenbits.xen.org/xen.git xen_4_13 && cd xen_4_13 && git reset --hard RELEASE-4.13.0
+
+    - name: compile Xen with CBMC via one-line-scan
+      run: ls
+      run: pwd
+      run: ls src/*
+      run: ln -sf src/goto-cc/goto-cc src/goto-cc/goto-ld
+      run: ln -sf src/goto-cc/goto-cc src/goto-cc/goto-as
+      run: ln -sf src/goto-cc/goto-cc src/goto-cc/goto-g++
+      run: PATH=$PATH:src/cbmc:src/goto-cc one-line-scan/one-line-scan --no-analysis --trunc-existing --extra-cflags -Wno-error -o CPROVER -j 3 -- make -C xen xen -j $(nproc) -k 


### PR DESCRIPTION
In the past, changes to CPROVER tools resulted in a broken build for
systems software like e.g. Xen. To avoid this issue in the future, we
want to integrate Xen compilation into continuous testing. This allows
to identify issues early, and fix them appropriately.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

<!---
Thank you for your contribution. Please make sure your pull request fulfils all of the below requirements. If you cannot currently tick all the boxes, but would still like to create a PR, then add the label "work in progress" and assign the PR to yourself.
--->

- [x] Each commit message has a non-empty body, explaining why the change was made.
- [x] Methods or procedures I have added are documented, following the guidelines provided in CODING_STANDARD.md.
- [x] The feature or user visible behaviour I have added or modified has been documented in the User Guide in doc/cprover-manual/
- [x] Regression or unit tests are included, or existing tests cover the modified code (in this case I have detailed which ones those are in the commit message).
- [x] My commit message includes data points confirming performance improvements (if claimed).
- [x] My PR is restricted to a single feature or bugfix.
- [x] White-space or formatting changes outside the feature-related changed lines are in commits of their own.

<!---
See, e.g., https://chris.beams.io/posts/git-commit/ for general guidelines on commit messages.

If you have created commits mixing multiple features and/or unrelated white-space changes, use a sequence involving git reset and git add -p to fix this.
--->

### Note:

Currently, this is considered being in testing github actions.